### PR TITLE
Containerize API with Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:1.22 AS build
+WORKDIR /build
+COPY . .
+RUN go mod download
+RUN CGO_ENABLED=0 GOOS=linux go build -o directory-api
+
+FROM alpine:latest AS final
+WORKDIR /app
+COPY --from=build /build/directory-api .
+COPY --from=build /build/.env .
+
+EXPOSE 8080
+
+ENTRYPOINT ["./directory-api"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,7 @@
+name: directory-api
+services:
+  directory-api:
+    image: directory-api:latest
+    container_name: directory-api
+    ports:
+      - 8080:8080

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -3,7 +3,9 @@ version: '3'
 tasks:
   develop:
     cmds:
-      - cmd: go install github.com/golang/mock/mockgen@v1.6
-  compile:
+      - cmd: go mod download
+  docker:
     cmds:
-      - cmd: go build
+      - cmd: docker rm $(docker stop $(docker ps -a -q --filter ancestor=directory-api)) || true
+      - cmd: docker build -t directory-api .
+      - cmd: docker compose up -d


### PR DESCRIPTION
Use `task docker` to run the API.

Leverages docker build and compose to later be used in production.