### PR TITLE
Switch to routing with chi

### DIFF
--- a/cli/server/config.go
+++ b/cli/server/config.go
@@ -1,11 +1,12 @@
 package cli
 
 import (
-	"directory/pkg/config"
 	"github.com/kelseyhightower/envconfig"
+
+	"directory/pkg/config"
 )
 
-func load() (cfg *config.Config, err error) {
+func configFromEnv() (cfg *config.Config, err error) {
 	cfg = new(config.Config)
 	err = envconfig.Process("", cfg)
 	return

--- a/cli/server/server.go
+++ b/cli/server/server.go
@@ -2,14 +2,15 @@ package cli
 
 import (
 	"context"
-	"directory/internal/services"
-	version "directory/pkg"
 	"fmt"
-	"golang.org/x/sync/errgroup"
 	"os"
 	"os/signal"
 	"syscall"
 
+	"golang.org/x/sync/errgroup"
+
+	"directory/internal/services"
+	version "directory/pkg"
 	"directory/pkg/logger"
 	"directory/pkg/router"
 	"directory/pkg/server"
@@ -22,7 +23,7 @@ func (c *Command) Run() error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	cfg, err := load()
+	cfg, err := configFromEnv()
 	if err != nil {
 		logger.Error(ctx, "error loading configuration", err)
 		os.Exit(1)

--- a/cli/server/server.go
+++ b/cli/server/server.go
@@ -30,7 +30,7 @@ func (c *Command) Run() error {
 
 	s := &server.Server{
 		Address:           cfg.Server.Address,
-		Handler:           router.New(database.New(cfg.Database.Driver, cfg.Database.Source)),
+		Handler:           router.New(database.New(cfg.Database.Driver, cfg.Database.Source)).Mux,
 		ReadHeaderTimeout: cfg.Server.ReadHeaderTimeout,
 	}
 

--- a/cli/server/server.go
+++ b/cli/server/server.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"directory/internal/services"
 	version "directory/pkg"
 	"fmt"
 	"golang.org/x/sync/errgroup"
@@ -9,7 +10,6 @@ import (
 	"os/signal"
 	"syscall"
 
-	"directory/pkg/database"
 	"directory/pkg/logger"
 	"directory/pkg/router"
 	"directory/pkg/server"
@@ -28,9 +28,14 @@ func (c *Command) Run() error {
 		os.Exit(1)
 	}
 
+	handler := router.New()
+	for _, service := range services.Services {
+		service.RegisterRoutes(handler)
+	}
+
 	s := &server.Server{
 		Address:           cfg.Server.Address,
-		Handler:           router.New(database.New(cfg.Database.Driver, cfg.Database.Source)).Mux,
+		Handler:           handler,
 		ReadHeaderTimeout: cfg.Server.ReadHeaderTimeout,
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -7,3 +7,5 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.22
 	golang.org/x/sync v0.7.0
 )
+
+require github.com/go-chi/chi v1.5.5 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,8 @@ module directory
 go 1.22
 
 require (
+	github.com/go-chi/chi/v5 v5.1.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/mattn/go-sqlite3 v1.14.22
 	golang.org/x/sync v0.7.0
 )
-
-require github.com/go-chi/chi v1.5.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/go-chi/chi v1.5.5 h1:vOB/HbEMt9QqBqErz07QehcOKHaWFtuj87tTDVz2qXE=
+github.com/go-chi/chi v1.5.5/go.mod h1:C9JqLr3tIYjDOZpzn+BCuxY8z8vmca43EeMgyZt7irw=
 github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/go-chi/chi v1.5.5 h1:vOB/HbEMt9QqBqErz07QehcOKHaWFtuj87tTDVz2qXE=
-github.com/go-chi/chi v1.5.5/go.mod h1:C9JqLr3tIYjDOZpzn+BCuxY8z8vmca43EeMgyZt7irw=
+github.com/go-chi/chi/v5 v5.1.0 h1:acVI1TYaD+hhedDJ3r54HyA6sExp3HfXq7QWEEY/xMw=
+github.com/go-chi/chi/v5 v5.1.0/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
 github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=

--- a/internal/services/directory/service.go
+++ b/internal/services/directory/service.go
@@ -3,6 +3,7 @@ package directory
 import (
 	"database/sql"
 	"encoding/json"
+	"github.com/go-chi/chi"
 	"net/http"
 )
 
@@ -14,8 +15,11 @@ func NewService(db *sql.DB) *Service {
 	return &Service{database: db}
 }
 
-func (s *Service) ListLocal(writer http.ResponseWriter, request *http.Request) {
+func (s *Service) ListLocal(w http.ResponseWriter, r *http.Request) {
 	directory := &Directory{
+		Country: chi.URLParam(r, "country"),
+		State:   chi.URLParam(r, "state"),
+		City:    chi.URLParam(r, "city"),
 		Listings: []*Listing{
 			{
 				Type:  POLICE,
@@ -33,10 +37,15 @@ func (s *Service) ListLocal(writer http.ResponseWriter, request *http.Request) {
 	}
 
 	response, err := json.Marshal(directory)
-
-	writer.WriteHeader(http.StatusOK)
-	_, err = writer.Write(response)
 	if err != nil {
+		http.Error(w, "Error marshalling JSON", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	_, err = w.Write(response)
+	if err != nil {
+		http.Error(w, "Error writing response", http.StatusInternalServerError)
 		return
 	}
 }

--- a/internal/services/directory/service.go
+++ b/internal/services/directory/service.go
@@ -3,8 +3,9 @@ package directory
 import (
 	"database/sql"
 	"encoding/json"
-	"github.com/go-chi/chi"
 	"net/http"
+
+	"github.com/go-chi/chi/v5"
 )
 
 type Service struct {

--- a/internal/services/directory/service.go
+++ b/internal/services/directory/service.go
@@ -12,8 +12,8 @@ type Service struct {
 	database *sql.DB
 }
 
-func NewService(db *sql.DB) *Service {
-	return &Service{database: db}
+func New() *Service {
+	return &Service{}
 }
 
 func (s *Service) RegisterRoutes(mux *chi.Mux) {

--- a/internal/services/directory/service.go
+++ b/internal/services/directory/service.go
@@ -16,6 +16,10 @@ func NewService(db *sql.DB) *Service {
 	return &Service{database: db}
 }
 
+func (s *Service) RegisterRoutes(mux *chi.Mux) {
+	mux.Get("/countries/{country}/states/{state}/cities/{city}", s.ListLocal)
+}
+
 func (s *Service) ListLocal(w http.ResponseWriter, r *http.Request) {
 	directory := &Directory{
 		Country: chi.URLParam(r, "country"),

--- a/internal/services/directory/types.go
+++ b/internal/services/directory/types.go
@@ -1,6 +1,10 @@
 package directory
 
 type Directory struct {
+	Country string `json:"country"`
+	State   string `json:"state"`
+	City    string `json:"city"`
+
 	Listings []*Listing `json:"listings"`
 	Ads      []*Ad      `json:"ads"`
 }

--- a/internal/services/services.go
+++ b/internal/services/services.go
@@ -1,0 +1,7 @@
+package services
+
+import "github.com/go-chi/chi/v5"
+
+type Service interface {
+	RegisterRoutes(r chi.Router)
+}

--- a/internal/services/services.go
+++ b/internal/services/services.go
@@ -1,7 +1,15 @@
 package services
 
-import "github.com/go-chi/chi/v5"
+import (
+	"github.com/go-chi/chi/v5"
+
+	"directory/internal/services/directory"
+)
 
 type Service interface {
-	RegisterRoutes(r chi.Router)
+	RegisterRoutes(mux *chi.Mux)
+}
+
+var Services = []Service{
+	directory.New(),
 }

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -2,7 +2,6 @@ package database
 
 import (
 	"database/sql"
-	_ "github.com/mattn/go-sqlite3"
 )
 
 func New(driver string, source string) (database *sql.DB) {

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -1,26 +1,14 @@
 package router
 
 import (
-	"database/sql"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
-
-	"directory/internal/services/directory"
 )
 
-type Router struct {
-	Mux *chi.Mux
-}
+func New() (router *chi.Mux) {
+	router = chi.NewRouter()
 
-func New(db *sql.DB) (router *Router) {
-	router = &Router{
-		Mux: chi.NewRouter(),
-	}
-
-	router.Mux.Use(middleware.Logger)
-
-	directoryService := directory.NewService(db)
-	directoryService.RegisterRoutes(router.Mux)
+	router.Use(middleware.Logger)
 
 	return
 }

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -2,16 +2,11 @@ package router
 
 import (
 	"database/sql"
-	"net/http"
-
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 
 	"directory/internal/services/directory"
 )
-
-type routes map[string]map[string]http.HandlerFunc
-type methods map[string]http.HandlerFunc
 
 type Router struct {
 	Mux *chi.Mux
@@ -25,8 +20,7 @@ func New(db *sql.DB) (router *Router) {
 	router.Mux.Use(middleware.Logger)
 
 	directoryService := directory.NewService(db)
-
-	router.Mux.Get("/countries/{country}/states/{state}/cities/{city}", directoryService.ListLocal)
+	directoryService.RegisterRoutes(router.Mux)
 
 	return
 }

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -4,8 +4,8 @@ import (
 	"database/sql"
 	"net/http"
 
-	"github.com/go-chi/chi"
-	"github.com/go-chi/chi/middleware"
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
 
 	"directory/internal/services/directory"
 )

--- a/test/directory.http
+++ b/test/directory.http
@@ -1,1 +1,1 @@
-GET http://localhost:8080/directory
+GET http://localhost:8080/countries/US/states/MA/cities/Boston


### PR DESCRIPTION
The initial routing solution was clunky and untenable.

> chi is a lightweight, idiomatic and composable router for building Go HTTP services. It's especially good at helping you write large REST API services that are kept maintainable as your project grows and changes.

It also includes other useful features like [middleware](https://github.com/go-chi/chi/blob/master/middleware), [render](https://github.com/go-chi/render) and [docgen](https://github.com/go-chi/docgen).